### PR TITLE
Various fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 // https://regex101.com/r/SQrOlx/14
 export default function issueRegex() {
-	return /(?<![\w./-])(?:(\w[\w.-]{0,38})\/(\w[\w.-]{0,99}))?#([1-9]\d{0,99})\b/g;
+	return /(?<![\w./-])(?:(?<org>\w[\w.-]{0,38})\/(?<repo>\w[\w.-]{0,99}))?#(?<num>[1-9]\d{0,99})\b/g;
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 // https://regex101.com/r/SQrOlx/14
 export default function issueRegex() {
-	return /(?<![\w./-])(?:(?<org>\w[\w.-]{0,38})\/(?<repo>\w[\w.-]{0,99}))?#(?<num>[1-9]\d{0,99})\b/g;
+	return /(?<![\w./-])(?:(?<organization>\w[\w.-]{0,38})\/(?<repository>\w[\w.-]{0,99}))?#(?<issueNumber>[1-9]\d{0,99})\b/g;
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 // https://regex101.com/r/SQrOlx/14
 export default function issueRegex() {
-	return /(?<!\w)(?:(?<organization>[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?)\/(?<repository>[\w.-]{1,100}))?(?<!(?:\/\.{1,2}))#(?<issueNumber>[1-9]\d{0,99})\b/gi;
+	return /(?<!\w)(?:(?<organization>[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?)\/(?<repository>[\w.-]{1,100}))?(?<!(?:\/\.{1,2}))#(?<issueNumber>[1-9]\d{0,9})\b/gi;
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 // https://regex101.com/r/SQrOlx/14
 export default function issueRegex() {
-	return /(?<![\w./-])(?:(?<organization>\w[\w.-]{0,38})\/(?<repository>\w[\w.-]{0,99}))?#(?<issueNumber>[1-9]\d{0,99})\b/g;
+	return /(?<!\w)(?:(?<organization>[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?)\/(?<repository>[\w.-]{1,100}))?(?<!(?:\/\.{1,2}))#(?<issueNumber>[1-9]\d{0,99})\b/gi;
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 // https://regex101.com/r/SQrOlx/14
 export default function issueRegex() {
-	return /(?:(?<![/\w-.])\w[\w-.]+?\/\w[\w-.]+?|\B)#[1-9]\d*?\b/g;
+	return /(?<![\w./-])(?:(\w[\w.-]{0,38})\/(\w[\w.-]{0,99}))?#([1-9]\d{0,99})\b/g;
 }

--- a/package.json
+++ b/package.json
@@ -42,5 +42,9 @@
 		"ava": "^3.15.0",
 		"tsd": "^0.17.0",
 		"xo": "^0.44.0"
+	},
+	"prettier": {
+		"arrowParens": "avoid",
+		"singleQuote": true
 	}
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 	},
 	"prettier": {
 		"arrowParens": "avoid",
-		"singleQuote": true
+		"singleQuote": true,
+		"trailingComma": "all"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,8 @@ import issueRegex from 'issue-regex';
 ```
 
 Organisation name, repository name, and issue number are also available
-individually in capturing groups 1-3, or named groups `org`, `repo`, and `num`:
+individually in capturing groups 1-3, or named groups `organization`,
+`repository`, and `issueNumber`:
 
 ```js
 issueRegex().exec('Fixes avajs/ava#1023'));
@@ -29,7 +30,7 @@ issueRegex().exec('Fixes avajs/ava#1023'));
   '1023',
   index: 6,
   input: 'Fixes avajs/ava#1023',
-  groups: [Object: null prototype] { org: 'avajs', repo: 'ava', num: '1023' }
+  groups: [Object: null prototype] { organization: 'avajs', repository: 'ava', issueNumber: '1023' }
 ]
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ import issueRegex from 'issue-regex';
 ```
 
 Organisation name, repository name, and issue number are also available
-individually in capturing groups 1-3:
+individually in capturing groups 1-3, or named groups `org`, `repo`, and `num`:
 
 ```js
 issueRegex().exec('Fixes avajs/ava#1023'));
@@ -29,7 +29,7 @@ issueRegex().exec('Fixes avajs/ava#1023'));
   '1023',
   index: 6,
   input: 'Fixes avajs/ava#1023',
-  groups: undefined
+  groups: [Object: null prototype] { org: 'avajs', repo: 'ava', num: '1023' }
 ]
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,22 @@ import issueRegex from 'issue-regex';
 //=> ['#143', 'avajs/ava#1023']
 ```
 
+Organisation name, repository name, and issue number are also available
+individually in capturing groups 1-3:
+
+```js
+issueRegex().exec('Fixes avajs/ava#1023'));
+[
+  'avajs/ava#1023',
+  'avajs',
+  'ava',
+  '1023',
+  index: 6,
+  input: 'Fixes avajs/ava#1023',
+  groups: undefined
+]
+```
+
 ## API
 
 ### issueRegex()

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,8 @@
 
 ## Install
 
-```
-$ npm install issue-regex
+```sh
+npm install issue-regex
 ```
 
 ## Usage
@@ -17,21 +17,25 @@ import issueRegex from 'issue-regex';
 //=> ['#143', 'avajs/ava#1023']
 ```
 
-Organisation name, repository name, and issue number are also available
-individually in capturing groups 1-3, or named groups `organization`,
-`repository`, and `issueNumber`:
+Organization name, repository name, and issue number are also available individually in capturing groups 1-3, or named groups `organization`, `repository`, and `issueNumber`:
 
 ```js
-issueRegex().exec('Fixes avajs/ava#1023'));
+issueRegex().exec('Fixes avajs/ava#1023');
+/*
 [
-  'avajs/ava#1023',
-  'avajs',
-  'ava',
-  '1023',
-  index: 6,
-  input: 'Fixes avajs/ava#1023',
-  groups: [Object: null prototype] { organization: 'avajs', repository: 'ava', issueNumber: '1023' }
+	'avajs/ava#1023',
+	'avajs',
+	'ava',
+	'1023',
+	index: 6,
+	input: 'Fixes avajs/ava#1023',
+	groups: {
+		organization: 'avajs',
+		repository: 'ava',
+		issueNumber: '1023'
+	}
 ]
+*/
 ```
 
 ## API

--- a/test.js
+++ b/test.js
@@ -49,12 +49,8 @@ const nonMatches = [
 	// maxLength of 100. See issue #11.
 	'foo/thisrepositorynameistoolongxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx#123',
 
-	// A GitHub issue number shouldn't have an infinite number of digits. It's
-	// difficult to choose a cut-off point here because GitHub hasn't published
-	// any information on limits on the number of issues per repository. Here we
-	// choose a (completely arbitrary) limit of 10^100. This can probably be set
-	// much lower, but how much lower? The closer we get to a realistic number,
-	// the higher the likelihood of a false negative.
+	// A GitHub issue number shouldn't have an infinite number of digits. Limit to
+	// 10B issues (10^10-1).
 	'#11111111111',
 	'foo/thisissuenumberistoolong#11111111111',
 

--- a/test.js
+++ b/test.js
@@ -10,8 +10,8 @@ const matches = [
 	'a/foo#1',
 	'thisorganisationnameislongbutokxxxxxxxx/foo#123',
 	'foo/thisrepositorynameislongbutokxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx#123',
-	'#1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
-	'foo/longbutokissuenumber#1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
+	'#1111111111',
+	'foo/longbutokissuenumber#1111111111',
 	'foo/-#123',
 	'foo/-bar#123',
 	'foo/bar-#123',
@@ -55,8 +55,8 @@ const nonMatches = [
 	// choose a (completely arbitrary) limit of 10^100. This can probably be set
 	// much lower, but how much lower? The closer we get to a realistic number,
 	// the higher the likelihood of a false negative.
-	'#11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
-	'foo/thisissuenumberistoolong#11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
+	'#11111111111',
+	'foo/thisissuenumberistoolong#11111111111',
 
 	'foo_bar/bar',
 	'-foo/bar',

--- a/test.js
+++ b/test.js
@@ -87,4 +87,8 @@ test('capturing groups', t => {
 	t.is(match[1], 'foo');
 	t.is(match[2], 'bar');
 	t.is(match[3], '123');
+
+	t.is(match.groups.org, 'foo');
+	t.is(match.groups.repo, 'bar');
+	t.is(match.groups.num, '123');
 });

--- a/test.js
+++ b/test.js
@@ -10,7 +10,20 @@ const matches = [
 	'a/foo#1',
 	'thisorganisationnameislongbutokxxxxxxxx/foo#123',
 	'foo/thisrepositorynameislongbutokxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx#123',
+	'#1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
 	'foo/longbutokissuenumber#1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
+	'foo/-#123',
+	'foo/-bar#123',
+	'foo/bar-#123',
+	'foo/foo-bar#123',
+	'foo/.bar#123',
+	'foo/..bar#123',
+	'foo/...#123',
+	'foo/_#123',
+	'foo/0#123',
+	'0/bar#123',
+	'1/1#1',
+	'Foo/Bar#1',
 ];
 
 const nonMatches = [
@@ -23,8 +36,6 @@ const nonMatches = [
 	'sindresorhus/dofle#0',
 	'dofle#33',
 	'#123hashtag',
-	'non/-repo#123',
-	'this/is/not/repo#123',
 
 	// GitHub organization names can't be longer than 39 characters
 	// as of March 2022.
@@ -44,14 +55,22 @@ const nonMatches = [
 	// choose a (completely arbitrary) limit of 10^100. This can probably be set
 	// much lower, but how much lower? The closer we get to a realistic number,
 	// the higher the likelihood of a false negative.
+	'#11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
 	'foo/thisissuenumberistoolong#11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
+
+	'foo_bar/bar',
+	'-foo/bar',
+	'foo-/bar',
+	'foo.bar/bar',
+	'foo/.',
+	'foo/..',
 ];
 
 test('main', t => {
-	t.deepEqual(
-		'Fixes #143 and avajs/ava#1023'.match(issueRegex()),
-		['#143', 'avajs/ava#1023'],
-	);
+	t.deepEqual('Fixes #143 and avajs/ava#1023'.match(issueRegex()), [
+		'#143',
+		'avajs/ava#1023',
+	]);
 
 	for (const x of matches) {
 		t.is((issueRegex().exec(`foo ${x} bar`) || [])[0], x);
@@ -72,16 +91,25 @@ test('main #2', t => {
 	- From another repository: another/repo#123
 	- Crazy formatting: ano-ther.999/re_po#123
 	- In brackets: (#123), [#123], <another/repo#123>
+	- this/is/ok/repo#444
+	- this/is.ok/repo#444
+	- -ok/repo#444
+	- foo/-bar#123
+	- foo/-#123
+	- foo/.bar#123
+	- foo/...#123
+	- foo_bar/bar#123
 
 	Should NOT match:
 
 	- #0
 	- another/repo#0
 	- nonrepo#123
-	- non/-repo#123
 	- user_repo#123
-	- this/is/not/repo#123
 	- #123hashtag
+	- foo/.#111
+	- foo/..#222
+  - _foo/bar#123
 
 	#123`;
 
@@ -89,10 +117,17 @@ test('main #2', t => {
 		'#123',
 		'#666',
 		'another/repo#123',
-		'ano-ther.999/re_po#123',
+		'999/re_po#123',
 		'#123',
 		'#123',
 		'another/repo#123',
+		'ok/repo#444',
+		'ok/repo#444',
+		'ok/repo#444',
+		'foo/-bar#123',
+		'foo/-#123',
+		'foo/.bar#123',
+		'foo/...#123',
 		'#123',
 	];
 

--- a/test.js
+++ b/test.js
@@ -105,7 +105,7 @@ test('capturing groups', t => {
 	t.is(match[2], 'bar');
 	t.is(match[3], '123');
 
-	t.is(match.groups.org, 'foo');
-	t.is(match.groups.repo, 'bar');
-	t.is(match.groups.num, '123');
+	t.is(match.groups.organization, 'foo');
+	t.is(match.groups.repository, 'bar');
+	t.is(match.groups.issueNumber, '123');
 });

--- a/test.js
+++ b/test.js
@@ -25,8 +25,25 @@ const nonMatches = [
 	'#123hashtag',
 	'non/-repo#123',
 	'this/is/not/repo#123',
+
+	// GitHub organization names can't be longer than 39 characters
+	// as of March 2022.
+	// Source: GitHub shows an error message when trying to create
+	// an organization with a longer name. See issue #11.
 	'thisorganisationnameistoolongxxxxxxxxxxx/foo#123',
+
+	// GitHub repository names can't be longer than 100 characters
+	// as of March 2022.
+	// Source: The text box on the repository creation page has a
+	// maxLength of 100. See issue #11.
 	'foo/thisrepositorynameistoolongxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx#123',
+
+	// A GitHub issue number shouldn't have an infinite number of digits. It's
+	// difficult to choose a cut-off point here because GitHub hasn't published
+	// any information on limits on the number of issues per repository. Here we
+	// choose a (completely arbitrary) limit of 10^100. This can probably be set
+	// much lower, but how much lower? The closer we get to a realistic number,
+	// the higher the likelihood of a false negative.
 	'foo/thisissuenumberistoolong#11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
 ];
 

--- a/test.js
+++ b/test.js
@@ -6,6 +6,11 @@ const matches = [
 	'#3223',
 	'sindresorhus/dofle#33',
 	'foo-bar/unicorn.rainbow#21',
+	'foo/a#1',
+	'a/foo#1',
+	'thisorganisationnameislongbutokxxxxxxxx/foo#123',
+	'foo/thisrepositorynameislongbutokxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx#123',
+	'foo/longbutokissuenumber#1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
 ];
 
 const nonMatches = [
@@ -20,6 +25,9 @@ const nonMatches = [
 	'#123hashtag',
 	'non/-repo#123',
 	'this/is/not/repo#123',
+	'thisorganisationnameistoolongxxxxxxxxxxx/foo#123',
+	'foo/thisrepositorynameistoolongxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx#123',
+	'foo/thisissuenumberistoolong#11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
 ];
 
 test('main', t => {
@@ -72,4 +80,11 @@ test('main #2', t => {
 	];
 
 	t.deepEqual(actual.match(issueRegex()), expected);
+});
+
+test('capturing groups', t => {
+	const match = issueRegex().exec('foo/bar#123');
+	t.is(match[1], 'foo');
+	t.is(match[2], 'bar');
+	t.is(match[3], '123');
 });


### PR DESCRIPTION
- Match single-character organisation or repository name
- Don't match organisation or repository name that are too long
- Don't match issue numbers greater than 10^100-1
- Put organisation name, repository name and issue number into capturing groups 1, 2 and 3.
- Add missing Prettier configuration

Fixes #9, Fixes #10, Fixes #11, Fixes #12, Fixes #14